### PR TITLE
refactor: Normalize crypto library

### DIFF
--- a/app/backend/src/lib/crypto.py
+++ b/app/backend/src/lib/crypto.py
@@ -2,19 +2,18 @@
 # -*- coding: utf-8 -*-
 
 import uuid 
-from typing import List
 from datetime import datetime, timezone   
 from .datatypes import FileFragment, EncryptedFile
 from cryptography.fernet import Fernet
 
 class Crypto:
-    _FRAGMENT_SIZE = 1024 ** 2 # 1MB
+    _FRAGMENT_SIZE = 1024 ** 1024 # 1MB
 
     def __init__(self, key):
         self.__key = key 
         self.__cipher = Fernet(self.__key)
 
-    def _fragment_token(self, token: bytes) -> List[FileFragment]:
+    def _fragment_bytes(self, token: bytes) -> list[FileFragment]:
         """
         Fragment a tokenized (encrypted) file into smaller chunks. Each chunk is represented as a dictionary.
 
@@ -22,7 +21,7 @@ class Crypto:
             token (bytes): The file encrypted using Fernet's token format.
 
         Returns:
-            List[FileFragment]: A list of file fragments. To see FileFragment attributes refer to `datatypes` module documentation.
+            list[FileFragment]: A list of file fragments. To see FileFragment attributes refer to `datatypes` module documentation.
         """
         fragments = []
         fragment_uuid = str(uuid.uuid4())
@@ -37,7 +36,7 @@ class Crypto:
         
         return fragments
 
-    def encrypt_file(self, file_data: bytes, user_id: str) -> EncryptedFile:
+    def encrypt(self, file_data: bytes, user_id: str) -> EncryptedFile:
         """
         Encrypt a file and associate it with the user's ID. The file is fragmented into smaller chunks.
         
@@ -49,7 +48,7 @@ class Crypto:
             EncryptedFile: An object representing the encrypted file (data and metadata included). To see EncryptedFile attributes refer to `datatypes` module documentation.
         """
         token = self.__cipher.encrypt(file_data)  # Encrypt the file data as a Fermet's token format
-        fragments = self._fragment_token(token)
+        fragments = self._fragment_bytes(token)
         file_uuid = str(uuid.uuid4())
 
         encrypted_file = EncryptedFile(
@@ -62,17 +61,29 @@ class Crypto:
 
         return encrypted_file
     
-    def decrypt_fragmented_file(self, fragments: List[FileFragment]) -> bytes:
+    def _defragment_bytes(self, fragments: list[FileFragment]) -> bytes:
         """
-        Decrypt a fragmented file. The fragments are combined into a single byte string and then decrypted.
+        Combine the fragments into a single byte string. The fragments are sorted by their index to ensure the correct order.
 
         Args:
-            fragments (List[FileFragment]): The list of fragments to be decrypted.
+            fragments (list[FileFragment]): The list of fragments.
+
+        Returns:
+            bytes: The defragmented data.
+        """
+        return b"".join(frag.data for frag in sorted(fragments, key=lambda f: f.index))
+
+    def decrypt(self, data: list[FileFragment] | bytes) -> bytes:
+        """
+        Decrypt a file. If the passed data is fragmented, the fragments are combined into a single byte string and then decrypted.
+
+        Args:
+            data (list[FileFragment] | bytes): The list of fragments to be decrypted.
         
         Returns:
             bytes: The decrypted file data.
         """
-        sorted_fragments = sorted(fragments, key=lambda x: x.index)  # Sort fragments by index
-        token = b"".join([frag.data for frag in sorted_fragments])
+        if isinstance(data, list):
+            data = self._defragment_bytes(data)
 
-        return self.__cipher.decrypt(token)
+        return self.__cipher.decrypt(data)

--- a/app/backend/src/lib/crypto.py
+++ b/app/backend/src/lib/crypto.py
@@ -7,7 +7,7 @@ from .datatypes import FileFragment, EncryptedFile
 from cryptography.fernet import Fernet
 
 class Crypto:
-    _FRAGMENT_SIZE = 1024 ** 1024 # 1MB
+    _FRAGMENT_SIZE = 1024 * 1024 # 1MB
 
     def __init__(self, key):
         self.__key = key 

--- a/tests/unit/test_crypto.py
+++ b/tests/unit/test_crypto.py
@@ -47,7 +47,11 @@ def token(key, data):
 
 @pytest.fixture
 def fragments(crypto, token):
-    return crypto._fragment_token(token)
+    return crypto._fragment_bytes(token)
+
+@pytest.fixture
+def non_fragmented_encrypted_data(key, data):
+    return Fernet(key).encrypt(data)
 
 # ----------------------
 # Tests
@@ -55,9 +59,9 @@ def fragments(crypto, token):
 
 def test_encrypted_file_datatype_is_valid(crypto, data, user_id):
     """
-    Ensure that encrypt_file returns an EncryptedFile with all expected types and attributes
+    Ensure that encrypt_file returns an EncryptedFile with all expected types and attributes.
     """
-    encrypted_data = crypto.encrypt_file(data, user_id)
+    encrypted_data = crypto.encrypt(data, user_id)
 
     assert isinstance(encrypted_data, EncryptedFile)
     assert isinstance(encrypted_data.uuid, str)
@@ -68,7 +72,7 @@ def test_encrypted_file_datatype_is_valid(crypto, data, user_id):
 
 def test_fragment_file_datatype_is_valid(fragments):
     """
-    Check that each generated fragment is a valid FileFragment with correct types and indices
+    Check that each generated fragment is a valid FileFragment with correct types and indices.
     """
     assert isinstance(fragments, list)
     assert len(fragments) > 0
@@ -82,7 +86,7 @@ def test_fragment_file_datatype_is_valid(fragments):
 
 def test_fragments_has_correct_size(fragments, crypto):
     """
-    Verify that all fragments are sized correctly, with only the last one potentially smaller
+    Verify that all fragments are sized correctly, with only the last one potentially smaller.
     """
     for f in fragments[:-1]:
         assert len(f.data) == crypto._FRAGMENT_SIZE
@@ -91,63 +95,70 @@ def test_fragments_has_correct_size(fragments, crypto):
 
 def test_encrypt_then_decrypt_restores_original_data(crypto, data, user_id):
     """
-    Ensure that data remains the same after encrypting and decrypting
+    Ensure that data remains the same after encrypting and decrypting.
     """
-    encrypted_data = crypto.encrypt_file(data, user_id)
-    decrypted_data = crypto.decrypt_fragmented_file(encrypted_data.fragments)
+    encrypted_data = crypto.encrypt(data, user_id)
+    decrypted_data = crypto.decrypt(encrypted_data.fragments)
     assert decrypted_data == data
 
 def test_encrypted_file_metadata_is_correct(crypto, data, user_id, key):
     """
-    Validate that metadata in the EncryptedFile is accurate
+    Validate that metadata in the EncryptedFile is accurate.
     """
-    encrypted_data = crypto.encrypt_file(data, user_id)
+    encrypted_data = crypto.encrypt(data, user_id)
     assert encrypted_data.user_id == user_id
     assert encrypted_data.key == key
 
 def test_created_at_timestamp_is_close_to_now(crypto, data, user_id):
     """
-    Ensure created_at timestamp is within 1 second of current UTC time
+    Ensure created_at timestamp is within 1 second of current UTC time.
     """
-    encrypted_data = crypto.encrypt_file(data, user_id)
+    encrypted_data = crypto.encrypt(data, user_id)
     now_ts = int(datetime.now(timezone.utc).timestamp())
     created_at_ts = int(encrypted_data.created_at)
     assert abs(now_ts - created_at_ts) <= 1
 
 def test_encrypt_empty_file(crypto, user_id):
     """
-    Ensure that encrypting and decrypting an empty byte string works correctly
+    Ensure that encrypting and decrypting an empty byte string works correctly.
     """
     empty_file = b""
-    encrypted_data = crypto.encrypt_file(empty_file, user_id)
-    decrypted_data = crypto.decrypt_fragmented_file(encrypted_data.fragments)
+    encrypted_data = crypto.encrypt(empty_file, user_id)
+    decrypted_data = crypto.decrypt(encrypted_data.fragments)
 
     assert decrypted_data == empty_file
 
 @pytest.mark.parametrize("data", [20.0, 40.0], indirect=True)
 def test_encrypt_large_file_generates_multiple_fragments(crypto, user_id, data):
     """
-    Check that encrypting large files results in multiple fragments as expected
+    Check that encrypting large files results in multiple fragments as expected.
     """
-    encrypted_file = crypto.encrypt_file(data, user_id)
+    encrypted_file = crypto.encrypt(data, user_id)
 
     assert len(encrypted_file.fragments) > 1
 
 def test_decryption_works_even_fragment_disordered(crypto, user_id, data):
     """
-    Confirm that decryption still works when fragments are provided in a different order
+    Confirm that decryption still works when fragments are provided in a different order.
     """
-    encrypted_file = crypto.encrypt_file(data, user_id)
+    encrypted_file = crypto.encrypt(data, user_id)
 
     reversed_fragments = list(reversed(encrypted_file.fragments))
-    decrypted_data = crypto.decrypt_fragmented_file(reversed_fragments)
+    decrypted_data = crypto.decrypt(reversed_fragments)
+    assert decrypted_data == data
+
+def test_decryption_when_passed_non_fragment_data(crypto, non_fragmented_encrypted_data, data):
+    """
+    Ensure that decrypting a single non-fragmented encrypted file works as expected.
+    """
+    decrypted_data = crypto.decrypt(non_fragmented_encrypted_data)
     assert decrypted_data == data
 
 def test_decryption_fails_on_modified_fragment(crypto, user_id, data):
     """
-    Verify that tampering with a fragment causes decryption to fail with an InvalidToken error
+    Verify that tampering with a fragment causes decryption to fail with an InvalidToken error.
     """
-    encrypted_file = crypto.encrypt_file(data, user_id)
+    encrypted_file = crypto.encrypt(data, user_id)
     fragments = encrypted_file.fragments
 
     corrupted_data = bytearray(fragments[0].data)
@@ -155,4 +166,4 @@ def test_decryption_fails_on_modified_fragment(crypto, user_id, data):
     fragments[0].data = bytes(corrupted_data)
 
     with pytest.raises(InvalidToken):
-        crypto.decrypt_fragmented_file(fragments)
+        crypto.decrypt(fragments)


### PR DESCRIPTION
Crypto object will now expose two methods: `encrypt()` and `decrypt()`. The latter, now accepts both fragmented and non-fragmented data as input.
Also, unit tests has been refactored to use the renamed Crypto's methods.

Closes #37.